### PR TITLE
Fix mbatchd bug which prevented jobs in interactive queue from being

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ Release notes for OpenLava versions
 4.0beta2
 ============
 
+-- Fix mbatchd bug which prevented jobs in interactive queue from being
+   modified if LSB_DEFAULT_USER_GROUP was configured in lsf.conf.
 -- Add Platform MPI wrapper.
 -- Use bash for etc/openlava to support Ubuntu.
 -- Fixed rusage string parsing bug.

--- a/lsbatch/daemons/mbd.job.c
+++ b/lsbatch/daemons/mbd.job.c
@@ -6616,7 +6616,7 @@ mergeSubReq(struct submitReq *to, struct submitReq *old,
     }
 
     if (old->options & SUB_USER_GROUP) {
-        to->options = SUB_USER_GROUP;
+        to->options |= SUB_USER_GROUP;
         to->userGroup = strdup(old->userGroup);
     } else {
         to->userGroup = strdup("");


### PR DESCRIPTION
modified if LSB_DEFAULT_USER_GROUP was configured in lsf.conf.